### PR TITLE
feat: Adds the option to use the design as overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14221,6 +14221,12 @@
             "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
             "dev": true
         },
+        "tsc": {
+            "version": "1.20150623.0",
+            "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
+            "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU=",
+            "dev": true
+        },
         "tslib": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@storybook/theming": "^5.3.18",
         "@types/react": "^16.9.34",
         "babel-loader": "^8.1.0",
+        "tsc": "^1.20150623.0",
         "typescript": "^3.8.3"
     }
 }

--- a/src/components/OverlayButtons.tsx
+++ b/src/components/OverlayButtons.tsx
@@ -18,37 +18,41 @@ export default function OverlayButtons(props: OverlayButtonsProps) {
         onToggleDifference,
         overlayIsOpen,
         overlayIsLocked,
+        showDifference,
     } = props;
 
     // Only show additional options when the overlay is visible
     const additionalOptions = overlayIsOpen && (
         <>
-            <IconButton
+            <ToggleIconButton
+                active={overlayIsLocked}
                 className="iconButton"
                 title={overlayIsLocked ? "Unlock overlay" : "Lock overlay"}
                 onClick={onToggleLock}
             >
                 <Icons icon={overlayIsLocked ? "lock" : "unlock"} />
-            </IconButton>
-            <IconButton
+            </ToggleIconButton>
+            <ToggleIconButton
+                active={showDifference}
                 className="iconButton"
                 title="Show difference"
                 onClick={onToggleDifference}
             >
                 <Icons icon="mirror" />
-            </IconButton>
+            </ToggleIconButton>
         </>
     );
 
     return (
         <Container>
-            <IconButton
+            <ToggleIconButton
+                active={overlayIsOpen}
                 className="iconButton"
                 title={overlayIsOpen ? "Hide overlay" : "Show overlay"}
                 onClick={onToggleOverlay}
             >
                 <Icons icon={overlayIsOpen ? "eyeclose" : "eye"} />
-            </IconButton>
+            </ToggleIconButton>
             {additionalOptions}
         </Container>
     );
@@ -58,6 +62,9 @@ const Container = styled.div`
     display: flex;
     button {
         margin-left: 15px;
-        color: #999;
     }
 `;
+
+const ToggleIconButton = styled(IconButton)`
+    color: ${props => props.active ? props.theme.barSelectedColor : props.theme.barTextColor}
+`

--- a/src/components/OverlayButtons.tsx
+++ b/src/components/OverlayButtons.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Icons, IconButton } from "@storybook/components";
+import { styled } from "@storybook/theming";
+
+interface OverlayButtonsProps {
+    overlayIsOpen: boolean;
+    overlayIsLocked: boolean;
+    showDifference: boolean;
+    onToggleOverlay(): void;
+    onToggleLock(): void;
+    onToggleDifference(): void;
+}
+
+export default function OverlayButtons(props: OverlayButtonsProps) {
+    const {
+        onToggleOverlay,
+        onToggleLock,
+        onToggleDifference,
+        overlayIsOpen,
+        overlayIsLocked,
+    } = props;
+
+    // Only show additional options when the overlay is visible
+    const additionalOptions = overlayIsOpen && (
+        <>
+            <IconButton
+                className="iconButton"
+                title={overlayIsLocked ? "Unlock overlay" : "Lock overlay"}
+                onClick={onToggleLock}
+            >
+                <Icons icon={overlayIsLocked ? "lock" : "unlock"} />
+            </IconButton>
+            <IconButton
+                className="iconButton"
+                title="Show difference"
+                onClick={onToggleDifference}
+            >
+                <Icons icon="mirror" />
+            </IconButton>
+        </>
+    );
+
+    return (
+        <Container>
+            <IconButton
+                className="iconButton"
+                title={overlayIsOpen ? "Hide overlay" : "Show overlay"}
+                onClick={onToggleOverlay}
+            >
+                <Icons icon={overlayIsOpen ? "eyeclose" : "eye"} />
+            </IconButton>
+            {additionalOptions}
+        </Container>
+    );
+}
+
+const Container = styled.div`
+    display: flex;
+    button {
+        margin-left: 15px;
+        color: #999;
+    }
+`;

--- a/src/components/OverlayButtons.tsx
+++ b/src/components/OverlayButtons.tsx
@@ -61,7 +61,7 @@ export default function OverlayButtons(props: OverlayButtonsProps) {
 const Container = styled.div`
     display: flex;
     button {
-        margin-left: 15px;
+        margin-right: 15px;
     }
 `;
 

--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -61,7 +61,7 @@ const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: Overl
 /**
  * In order to not lose "focus" of the overlay when moving
  * the mouse very fast, there needs to be another element
- * aboce the iframe
+ * above the iframe
  */
 const DraggableArea = styled.div`
   position: absolute;

--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -41,19 +41,35 @@ const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: Overl
 
   const handleMouseDown = () => setMouseDown(true);
 
-  return <OverlayElement
-    src={url}
-    draggable={false}
-    onMouseDown={handleMouseDown}
-    style={{
-      transform: `translate(${position.x}px, ${position.y}px) scale(${scaling})`,
-      // For the difference filter to work correctly, opacity needs to be locked to 1
-      opacity: showDifference ? 1 : opacity,
-      pointerEvents: isLocked ? 'none' : 'all',
-      mixBlendMode: showDifference ? 'difference' : 'normal'
-    }}
-  />
+  return <>
+      {mouseDown && <DraggableArea />}
+      <OverlayElement
+        src={url}
+        draggable={false}
+        onMouseDown={handleMouseDown}
+        style={{
+          transform: `translate(${position.x}px, ${position.y}px) scale(${scaling})`,
+          // For the difference filter to work correctly, opacity needs to be locked to 1
+          opacity: showDifference ? 1 : opacity,
+          pointerEvents: isLocked ? 'none' : 'all',
+          mixBlendMode: showDifference ? 'difference' : 'normal'
+        }}
+      />
+    </>
 }
+
+/**
+ * In order to not lose "focus" of the overlay when moving
+ * the mouse very fast, there needs to be another element
+ * aboce the iframe
+ */
+const DraggableArea = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
 
 const OverlayElement = styled.img`
   position: absolute;

--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -17,14 +17,14 @@ interface OverlayImageProps {
 }
 
 const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: OverlayImageProps) => {
-  const [position, updatePosition] = useReducer(movementReducer, {x: 0, y: 0});
+  const [position, updatePosition] = useReducer(movementReducer, { x: 0, y: 0 });
   const [mouseDown, setMouseDown] = useState(false);
 
 
   useEffect(() => {
     const handleMouseUp = () => setMouseDown(false);
-    window.addEventListener('mouseup', handleMouseUp);
-    return () => window.removeEventListener('mouseup', handleMouseUp);
+    window.addEventListener("mouseup", handleMouseUp);
+    return () => window.removeEventListener("mouseup", handleMouseUp);
   }, []);
 
   useEffect(() => {
@@ -33,10 +33,10 @@ const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: Overl
     };
 
     if (mouseDown) {
-      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener("mousemove", handleMouseMove);
     }
 
-    return () => window.removeEventListener('mousemove', handleMouseMove);
+    return () => window.removeEventListener("mousemove", handleMouseMove);
   }, [mouseDown]);
 
   const handleMouseDown = () => setMouseDown(true);

--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect, useReducer } from "react"
+import { styled } from "@storybook/theming";
+
+const movementReducer = (state, offset) => {
+  return {
+    x: state.x + offset.x,
+    y: state.y + offset.y,
+  }
+}
+
+interface OverlayImageProps {
+  url: string;
+  opacity: number;
+  scaling: number;
+  isLocked: boolean;
+  showDifference: boolean;
+}
+
+const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: OverlayImageProps) => {
+  const [position, updatePosition] = useReducer(movementReducer, {x: 0, y: 0});
+  const [mouseDown, setMouseDown] = useState(false);
+
+
+  useEffect(() => {
+    const handleMouseUp = () => setMouseDown(false);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => window.removeEventListener('mouseup', handleMouseUp);
+  }, []);
+
+  useEffect(() => {
+    const handleMouseMove = (e) => {
+      updatePosition({x: e.movementX, y: e.movementY});
+    };
+
+    if (mouseDown) {
+      window.addEventListener('mousemove', handleMouseMove);
+    }
+
+    return () => window.removeEventListener('mousemove', handleMouseMove);
+  }, [mouseDown]);
+
+  const handleMouseDown = () => setMouseDown(true);
+
+  return <OverlayElement
+    src={url}
+    draggable={false}
+    onMouseDown={handleMouseDown}
+    style={{
+      transform: `translate(${position.x}px, ${position.y}px) scale(${scaling})`,
+      // For the difference filter to work correctly, opacity needs to be locked to 1
+      opacity: showDifference ? 1 : opacity,
+      pointerEvents: isLocked ? 'none' : 'all',
+      mixBlendMode: showDifference ? 'difference' : 'normal'
+    }}
+  />
+}
+
+const OverlayElement = styled.img`
+  position: absolute;
+  left: 0;
+  top: 0;
+  cursor: move;
+  transform-origin: top left;
+`
+
+export default OverlayImage;

--- a/src/components/OverlayPanel.tsx
+++ b/src/components/OverlayPanel.tsx
@@ -1,0 +1,124 @@
+import React, { useCallback, useReducer } from "react";
+import { styled } from "@storybook/theming";
+
+import OverlayPortal from "./OverlayPortal";
+import OverlayButtons from "./OverlayButtons";
+import OverlayImage from "./OverlayImage";
+
+interface OverlayPanelProps {
+    image_url: string;
+}
+
+interface OverlayState {
+    showOverlay: boolean;
+    lockOverlay: boolean;
+    showDifference: boolean;
+    overlayScaling: number;
+    opacity: number;
+}
+
+const initialState: OverlayState = {
+    showOverlay: false,
+    lockOverlay: false,
+    showDifference: false,
+    overlayScaling: 0.5,
+    opacity: 1,
+};
+
+const OverlayPanel: React.FC<OverlayPanelProps> = ({ image_url }) => {
+    const [state, setState] = useReducer(
+        (state: OverlayState, newState: Partial<OverlayState>) => ({
+            ...state,
+            ...newState,
+        }),
+        initialState
+    );
+
+    const {
+        showOverlay,
+        lockOverlay,
+        showDifference,
+        overlayScaling,
+        opacity,
+    } = state;
+
+    const selectScaling = useCallback((event) => {
+        setState({ overlayScaling: event.target.value });
+    }, []);
+
+    const toggleOverlay = () => {
+        setState({ showOverlay: !showOverlay });
+    };
+
+    const toggleLock = () => {
+        setState({ lockOverlay: !lockOverlay });
+    };
+
+    const toggleDifference = () => {
+        setState({ showDifference: !showDifference });
+    };
+
+    const updateOpacity = (event) => {
+        setState({ opacity: event.currentTarget.value });
+    };
+
+    return (
+        <>
+            <OverlayButtons
+                overlayIsOpen={showOverlay}
+                overlayIsLocked={lockOverlay}
+                showDifference={showDifference}
+                onToggleOverlay={toggleOverlay}
+                onToggleLock={toggleLock}
+                onToggleDifference={toggleDifference}
+            />
+            {showOverlay && (
+                <OverlayOptions>
+                    Opacity
+                    <Input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value={opacity}
+                        onChange={updateOpacity}
+                    />
+                    Scaling
+                    <Select onChange={selectScaling} value={overlayScaling}>
+                        <option value={0.5}>x0.5</option>
+                        <option value={1}>x1</option>
+                        <option value={2}>x2</option>
+                    </Select>
+                </OverlayOptions>
+            )}
+            {showOverlay && (
+                <OverlayPortal>
+                    <OverlayImage
+                        url={image_url}
+                        opacity={opacity}
+                        isLocked={lockOverlay}
+                        scaling={overlayScaling}
+                        showDifference={showDifference}
+                    />
+                </OverlayPortal>
+            )}
+        </>
+    );
+};
+
+export default OverlayPanel;
+
+const Select = styled.select`
+    margin-left: 15px;
+`;
+
+const Input = styled.input`
+  margin-right: 30px;
+  margin-left: 15px;
+`
+
+const OverlayOptions = styled.div`
+    margin-left: 15px;
+    display: flex;
+    align-items: center;
+`;

--- a/src/components/OverlayPanel.tsx
+++ b/src/components/OverlayPanel.tsx
@@ -21,7 +21,7 @@ const initialState: OverlayState = {
     showOverlay: false,
     lockOverlay: false,
     showDifference: false,
-    overlayScaling: 1,
+    overlayScaling: 0.5,
     opacity: 1,
 };
 

--- a/src/components/OverlayPanel.tsx
+++ b/src/components/OverlayPanel.tsx
@@ -21,7 +21,7 @@ const initialState: OverlayState = {
     showOverlay: false,
     lockOverlay: false,
     showDifference: false,
-    overlayScaling: 0.5,
+    overlayScaling: 1,
     opacity: 1,
 };
 
@@ -115,6 +115,7 @@ const Select = styled.select`
 const Input = styled.input`
   margin-right: 30px;
   margin-left: 15px;
+  width: 100%;
 `
 
 const OverlayOptions = styled.div`

--- a/src/components/OverlayPanel.tsx
+++ b/src/components/OverlayPanel.tsx
@@ -6,7 +6,7 @@ import OverlayButtons from "./OverlayButtons";
 import OverlayImage from "./OverlayImage";
 
 interface OverlayPanelProps {
-    image_url: string;
+    imageUrl: string;
 }
 
 interface OverlayState {
@@ -25,7 +25,7 @@ const initialState: OverlayState = {
     opacity: 1,
 };
 
-const OverlayPanel: React.FC<OverlayPanelProps> = ({ image_url }) => {
+const OverlayPanel: React.FC<OverlayPanelProps> = ({ imageUrl }) => {
     const [state, setState] = useReducer(
         (state: OverlayState, newState: Partial<OverlayState>) => ({
             ...state,
@@ -94,7 +94,7 @@ const OverlayPanel: React.FC<OverlayPanelProps> = ({ image_url }) => {
             {showOverlay && (
                 <OverlayPortal>
                     <OverlayImage
-                        url={image_url}
+                        url={imageUrl}
                         opacity={opacity}
                         isLocked={lockOverlay}
                         scaling={overlayScaling}

--- a/src/components/OverlayPortal.tsx
+++ b/src/components/OverlayPortal.tsx
@@ -1,0 +1,10 @@
+import { createPortal } from 'react-dom';
+import { getOverlay } from '../utils/overlay';
+
+const OverlayPortal = ({ children }) => {
+  const overlay = getOverlay()
+
+  return createPortal(children, overlay);
+}
+
+export default OverlayPortal;

--- a/src/components/OverlayPortal.tsx
+++ b/src/components/OverlayPortal.tsx
@@ -2,7 +2,7 @@ import { createPortal } from 'react-dom';
 import { getOverlay } from '../utils/overlay';
 
 const OverlayPortal = ({ children }) => {
-  const overlay = getOverlay()
+  const overlay = getOverlay();
 
   return createPortal(children, overlay);
 }

--- a/src/components/ZeplinPanel.tsx
+++ b/src/components/ZeplinPanel.tsx
@@ -153,7 +153,7 @@ const ZeplinPanel: React.FC<ZeplinPanelProps> = ({ zeplinLink }) => {
             <Divider />
 
             <Header>
-                <OverlayPanel image_url={original_url}/>
+                <OverlayPanel imageUrl={original_url}/>
             </Header>
 
             <Divider />

--- a/src/components/ZeplinPanel.tsx
+++ b/src/components/ZeplinPanel.tsx
@@ -5,6 +5,7 @@ import HeaderButtons from "./HeaderButtons";
 
 import { getZeplinResource } from "../utils/api";
 import { relativeDate } from "../utils/date";
+import OverlayPanel from "./OverlayPanel";
 
 interface ZeplinkLink {
     name: string;
@@ -151,6 +152,12 @@ const ZeplinPanel: React.FC<ZeplinPanelProps> = ({ zeplinLink }) => {
 
             <Divider />
 
+            <Header>
+                <OverlayPanel image_url={original_url}/>
+            </Header>
+
+            <Divider />
+
             <ImageContainer>
                 <a
                     href={designLink}
@@ -204,7 +211,10 @@ const ImageContainer = styled.div`
 `;
 
 const Divider = styled.hr`
-    margin: 0 0 15px 0;
+    margin: 0 0 1px 0;
+    &:last-of-type {
+        margin-bottom: 15px;
+    }
 `;
 
 const Message = styled.p`

--- a/src/utils/overlay.ts
+++ b/src/utils/overlay.ts
@@ -1,0 +1,16 @@
+const getOverlay: () => HTMLDivElement = () =>  {
+  const previewWrapper = document.querySelector('#storybook-preview-wrapper');
+  let overlay = previewWrapper.querySelector('#storybook-zeplin-preview') as HTMLDivElement;
+
+  // Make sure overlay always returns something
+  if (!overlay) {
+    const imageContainer = document.createElement('div');
+    imageContainer.id = "storybook-zeplin-preview";
+    previewWrapper.appendChild(imageContainer);
+    overlay = imageContainer;
+  }
+
+  return overlay;
+}
+
+export { getOverlay };


### PR DESCRIPTION
This PR adds a new panel that enables the user to show the design on top of the story-iframe. The overlay can be moved around with drag and drop to align with the elements of the story as needed. I started developing this locally and this addition helped tremendously with implementing pixel-perfect components. This is basically a direct integration of extensions like [PerfectPixel](https://chrome.google.com/webstore/detail/perfectpixel-by-welldonec/dkaagdgjmgdmbnecmcefdhjekcoceebi?hl=en)

When the overlay is visible, multiple additional options are available:

**Lock/Unlock**

When the overlay is locked, `pointer-events: none` is set, so the story is interactive, and elements can be selected from the devtools directly through the design overlay. The overlay cannot be moved in this state.

**Difference**

Adds `mix-blend-mode: difference` to the overlay, so a pixel-by-pixel comparison can be seen. This addition was inspired by #2 

**Opacity Slider**

With this slider, the opacity of the overlay can be controlled as needed.

**Scaling Factor**

When testing this solution with our designs, the overlay was twice as big as it should be - I guess the Design is using a different pixel density than the screen, so scaling the overlay down to x0.5 matched with how the components should look. If the 0.5 factor is an edge case, and x1 scaling is more common, the default should be adjusted (currently I kept the default to x0.5). Available options are

* x0.5 (default)
* x1
* x2