### PR TITLE
Feature: Add ability to control zeplin overlay with Shift + arrow-keys

### DIFF
--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -39,6 +39,28 @@ const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: Overl
     return () => window.removeEventListener("mousemove", handleMouseMove);
   }, [mouseDown]);
 
+  // Ability to move zeplin overlay with Shift + Arrow keys
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.shiftKey && event.key === "ArrowUp") {
+        updatePosition({ x: 0, y: -1 });
+      }
+      if (event.shiftKey && event.key === "ArrowDown") {
+        updatePosition({ x: 0, y: 1 });
+      }
+      if (event.shiftKey && event.key === "ArrowRight") {
+        updatePosition({ x: 1, y: 0 });
+      }
+      if (event.shiftKey && event.key === "ArrowLeft") {
+        updatePosition({ x: - 1, y: 0 });
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   const handleMouseDown = () => setMouseDown(true);
 
   return <>

--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -20,7 +20,6 @@ const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: Overl
   const [position, updatePosition] = useReducer(movementReducer, { x: 0, y: 0 });
   const [mouseDown, setMouseDown] = useState(false);
 
-
   useEffect(() => {
     const handleMouseUp = () => setMouseDown(false);
     window.addEventListener("mouseup", handleMouseUp);
@@ -56,10 +55,12 @@ const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: Overl
       }
     }
 
-    window.addEventListener("keydown", handleKeyDown);
+    if (!isLocked) {
+      window.addEventListener("keydown", handleKeyDown);
+    }
 
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [isLocked]);
 
   const handleMouseDown = () => setMouseDown(true);
 

--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -38,7 +38,6 @@ const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: Overl
     return () => window.removeEventListener("mousemove", handleMouseMove);
   }, [mouseDown]);
 
-  // Ability to move zeplin overlay with Shift + Arrow keys
   useEffect(() => {
     const handleKeyDown = (event) => {
       if (event.shiftKey && event.key === "ArrowUp") {
@@ -51,7 +50,7 @@ const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: Overl
         updatePosition({ x: 1, y: 0 });
       }
       if (event.shiftKey && event.key === "ArrowLeft") {
-        updatePosition({ x: - 1, y: 0 });
+        updatePosition({ x: -1, y: 0 });
       }
     }
 


### PR DESCRIPTION
Hi @mertkahyaoglu! Awesome, repository!

This PR adds the ability to control overlay with Shift + Arrow keys. This ability might be helpful when you want to do pixel perfect. 