### PR TITLE
fix: define initial position of image overlay based on story layout

### DIFF
--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useReducer } from "react"
+import { useParameter } from "@storybook/api";
 import { styled } from "@storybook/theming";
 
 const movementReducer = (state, offset) => {
@@ -17,7 +18,9 @@ interface OverlayImageProps {
 }
 
 const OverlayImage = ({ url, opacity, scaling, isLocked, showDifference }: OverlayImageProps) => {
-  const [position, updatePosition] = useReducer(movementReducer, { x: 0, y: 0 });
+  const isPaddedLayout = useParameter('layout', 'padded') === 'padded';
+  const initialPosition = isPaddedLayout  ? 16 : 0;
+  const [position, updatePosition] = useReducer(movementReducer, { x: initialPosition, y: initialPosition });
   const [mouseDown, setMouseDown] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
Issue: #26

Now the addon should take the layout parameter into account when displaying the image overlay. It's very tricky to get the correct position when the layout is 'centered', given that the addon is running outside of the context of the story iframe, so I think for now it's already great that it will work for the most used layouts, which are 'padded' and 'fullscreen'. 
