### PR TITLE
Fix prepare command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12996,12 +12996,6 @@
             "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
             "dev": true
         },
-        "tsc": {
-            "version": "1.20150623.0",
-            "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-            "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU=",
-            "dev": true
-        },
         "tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
         "popular"
     ],
     "scripts": {
+        "prepare": "npm run build",
         "build": "tsc",
-        "prepublish": "tsc",
         "watch": "tsc --watch --preserveWatchOutput",
         "storybook": "NODE_ENV=development start-storybook -p 9001 -c .storybook --no-manager-cache",
         "build-storybook": "NODE_ENV=production build-storybook"
@@ -55,7 +55,6 @@
         "babel-loader": "^8.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "tsc": "^1.20150623.0",
         "typescript": "^4.4.3"
     },
     "storybook": {


### PR DESCRIPTION
While using the git URL as a npm dependency, we had two issues:
1. tsc version is outdated and it produces the following error:

> npm ERR! > storybook-zeplin@1.5.2-rc.0 prepublish
npm ERR! > tsc
npm ERR! 
npm ERR! error TS6047: Argument for '--target' option must be 'ES3', 'ES5', or 'ES6'.
npm ERR! error TS6046: Argument for '--module' option must be 'commonjs', 'amd', 'system' or 'umd'.
npm ERR! error TS5023: Unknown compiler option 'moduleResolution'.
npm ERR! error TS5023: Unknown compiler option 'strict'.
npm ERR! error TS5023: Unknown compiler option 'jsx'.
npm ERR! error TS5023: Unknown compiler option 'forceConsistentCasingInFileNames'.
npm ERR! error TS5023: Unknown compiler option 'esModuleInterop'.
npm ERR! error TS5023: Unknown compiler option 'allowSyntheticDefaultImports'.
npm ERR! error TS5023: Unknown compiler option 'types'.
npm ERR! error TS5023: Unknown compiler option 'skipLibCheck'.
npm ERR! npm WARN using --force Recommended protections disabled.
npm ERR! npm ERR! code 1
npm ERR! npm ERR! path /Users/sertac/.npm/_cacache/tmp/git-clone-a7a54df5
npm ERR! npm ERR! command failed
npm ERR! npm ERR! command sh -c tsc

2. `prepublish` command is deprecated. [Deprecation documentation](https://docs.npmjs.com/cli/v7/using-npm/scripts#prepare-and-prepublish)
