### PR TITLE
fix: Fix error handling and improve copies

### DIFF
--- a/src/components/PATForm.tsx
+++ b/src/components/PATForm.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from "react";
-import { Button, Form, Link } from "@storybook/components";
+import { Button, Form, Icons, Link } from "@storybook/components";
 import { styled } from "@storybook/theming";
 
 interface PATFormProps {
@@ -25,7 +25,7 @@ export const PATForm: FunctionComponent<PATFormProps> = ({ onSubmit }) => {
                 </Button>
             </StyledForm>
             <div>
-                You can create personal access token from the web app under
+                You can create personal access token using
                 {" "}
                 <Link
                     cancel={false}
@@ -35,8 +35,12 @@ export const PATForm: FunctionComponent<PATFormProps> = ({ onSubmit }) => {
                     Developer
                 </Link>
                 {" "}
-                tab in your profile page.
+                page in your Zeplin profile.
             </div>
+            <FillerRow />
+            <small>
+                <i>* The token will be stored in your browser's local storage. You can later remove it using the log out button</i>
+            </small>
         </Rows>
     );
 }
@@ -46,6 +50,7 @@ const Rows = styled.div`
     display: flex;
     flex-direction: column;
     gap: 22px;
+    height: 100%;
 `;
 
 const StyledForm = styled(Form)`
@@ -57,3 +62,8 @@ const StyledForm = styled(Form)`
 const StyledInput = styled(Form.Input)`
     flex: 1;
 `;
+
+const FillerRow = styled.div`
+    flex: 1;
+`;
+

--- a/src/components/ZeplinPanel.tsx
+++ b/src/components/ZeplinPanel.tsx
@@ -36,16 +36,6 @@ const initialState: ZeplinState = {
     linksFromConnectedComponents: null
 };
 
-const toLinks = (link: ZeplinLink[] | string | undefined): ZeplinLink[] => {
-    if (!link) {
-        return [];
-    }
-    if (typeof link === "string") {
-        return [{ link, name: "Component" }];
-    }
-    return link;
-}
-
 const ZeplinPanel: React.FC<ZeplinPanelProps> = ({ zeplinLink, onLogout }) => {
     const [state, setState] = useReducer(
         (state: ZeplinState, newState: Partial<ZeplinState>) => ({
@@ -64,16 +54,12 @@ const ZeplinPanel: React.FC<ZeplinPanelProps> = ({ zeplinLink, onLogout }) => {
 
     const fetchZeplinResource = async () => {
         // If the connected components are not loaded yet, we need to load them first
-        if (linksLoading && !designLink) {
+        if (linksLoading) {
             return;
         }
 
         if (!designLink) {
-            const formattedValue = JSON.stringify(zeplinLink, null, 2);
-            setState({
-                loading: false,
-                error: `Zeplin links are either missing or malformed. Received ${formattedValue}`,
-            });
+            setState({ loading: false });
             return;
         }
 
@@ -124,6 +110,22 @@ const ZeplinPanel: React.FC<ZeplinPanelProps> = ({ zeplinLink, onLogout }) => {
         return <Message>Loading…</Message>;
     }
 
+
+    if (!designLink && !LinksError) {
+        if (zeplinLink) {
+            return (
+                <Message>
+                    There is no connected component for this story.
+                </Message>
+            );
+        }
+        return (
+            <Message>
+                <strong>zeplinLink</strong> is not provided for this story.
+            </Message>
+        );
+    }
+
     if (error || LinksError) {
         return (
             <Rows>
@@ -143,14 +145,6 @@ const ZeplinPanel: React.FC<ZeplinPanelProps> = ({ zeplinLink, onLogout }) => {
                     {" first."}
                 </p>
             </Rows>
-        );
-    }
-
-    if (!designLink) {
-        return (
-            <Message>
-                <strong>zeplinLink</strong> is not provided for this story.
-            </Message>
         );
     }
 

--- a/src/components/hooks/useLinks.ts
+++ b/src/components/hooks/useLinks.ts
@@ -37,7 +37,12 @@ interface State {
     loading: boolean;
 }
 
-export const useLinks = (zeplinLink: ZeplinLink[] | string): State => {
+const isZeplinLinkValid = (link: unknown): link is ZeplinLink => {
+    return typeof (link as any)?.name === "string" && typeof (link as any)?.link === "string"
+
+}
+
+export const useLinks = (zeplinLink: unknown): State => {
     const [state, setState] = useReducer(
         (state: State, newState: State) => ({ ...state, ...newState }),
         {
@@ -52,9 +57,12 @@ export const useLinks = (zeplinLink: ZeplinLink[] | string): State => {
     useEffect(() => {
         if (!zeplinLink) {
             setState({ links: [], error: null, loading: false });
-        } else if (Array.isArray(zeplinLink)) {
+        } else if (Array.isArray(zeplinLink) && zeplinLink.every(isZeplinLinkValid)) {
             setState({ links: zeplinLink, error: null, loading: false });
-        } else {
+        } else if(Array.isArray(zeplinLink) || typeof zeplinLink !== "string") {
+            const formattedValue = JSON.stringify(zeplinLink, null, 2);
+            setState({ links: [], error: `Zeplin link is malformed. Received: ${formattedValue}`, loading: false });
+        }else {
             const projectId = getProjectIdFromProjectLink(zeplinLink);
             const styleguideId = getStyleguideIdFromStyleguideLink(zeplinLink);
             if (projectId || styleguideId) {

--- a/src/components/hooks/useLinks.ts
+++ b/src/components/hooks/useLinks.ts
@@ -62,7 +62,7 @@ export const useLinks = (zeplinLink: unknown): State => {
         } else if(Array.isArray(zeplinLink) || typeof zeplinLink !== "string") {
             const formattedValue = JSON.stringify(zeplinLink, null, 2);
             setState({ links: [], error: `Zeplin link is malformed. Received: ${formattedValue}`, loading: false });
-        }else {
+        } else {
             const projectId = getProjectIdFromProjectLink(zeplinLink);
             const styleguideId = getStyleguideIdFromStyleguideLink(zeplinLink);
             if (projectId || styleguideId) {

--- a/src/components/hooks/useLinks.ts
+++ b/src/components/hooks/useLinks.ts
@@ -6,7 +6,7 @@ import { useStorybookState } from "@storybook/api";
 import { getZeplinLinksFromConnectedComponents } from "../../utils/api";
 
 const getProjectIdFromProjectLink = (link: string): string | null => {
-    if (link.startsWith(`${ZEPLIN_APP_BASE}/project?`)) {
+    if (link.startsWith(`${ZEPLIN_APP_BASE}//project?`)) {
         const [, searchParams] = link.split("?");
         const result = /^pid=([\da-f]{24})$/.exec(searchParams);
         return result?.[1];
@@ -19,7 +19,7 @@ const getProjectIdFromProjectLink = (link: string): string | null => {
 }
 
 const getStyleguideIdFromStyleguideLink = (link: string): string | null => {
-    if (link.startsWith(`${ZEPLIN_APP_BASE}/styleguide?`)) {
+    if (link.startsWith(`${ZEPLIN_APP_BASE}//styleguide?`)) {
         const [, searchParams] = link.split("?");
         const result = /^stid=([\da-f]{24})$/.exec(searchParams);
         return result?.[1];


### PR DESCRIPTION
- Fix getting a project id from an app url.
- Fix showing a more accurate message when there is no link/connected component associated with the selected story
- Change the copy of the form for personal access tokens to emphasize that the token is stored locally.