### PR TITLE
fix zeplin component loading when zeplinLink is the same value for all stories

### DIFF
--- a/src/components/ZeplinPanel.tsx
+++ b/src/components/ZeplinPanel.tsx
@@ -46,7 +46,7 @@ const ZeplinPanel: React.FC<ZeplinPanelProps> = ({ zeplinLink, onLogout }) => {
         undefined
     );
 
-    const { links, loading: linksLoading, error: LinksError } = useLinks(zeplinLink);
+    const { links, linksLoading, error: LinksError } = useLinks(zeplinLink);
 
     const { selectedLink, zeplinData, zoomLevel, loading, error, user } = state;
 

--- a/src/components/hooks/useLinks.ts
+++ b/src/components/hooks/useLinks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useReducer } from "react";
 
 import { ZeplinLink } from "../../types/ZeplinLink";
 import { ZEPLIN_APP_BASE, ZEPLIN_WEB_BASE } from "../../constants";

--- a/src/components/hooks/useLinks.ts
+++ b/src/components/hooks/useLinks.ts
@@ -34,7 +34,7 @@ const getStyleguideIdFromStyleguideLink = (link: string): string | null => {
 interface State {
     links: ZeplinLink[];
     error: string | null;
-    loading: boolean;
+    linksLoading: boolean;
 }
 
 const isZeplinLinkValid = (link: unknown): link is ZeplinLink => {
@@ -48,7 +48,7 @@ export const useLinks = (zeplinLink: unknown): State => {
         {
             links: [],
             error: null,
-            loading: true,
+            linksLoading: false,
         },
         undefined
     );
@@ -56,17 +56,17 @@ export const useLinks = (zeplinLink: unknown): State => {
 
     useEffect(() => {
         if (!zeplinLink) {
-            setState({ links: [], error: null, loading: false });
+            setState({ links: [], error: null, linksLoading: false });
         } else if (Array.isArray(zeplinLink) && zeplinLink.every(isZeplinLinkValid)) {
-            setState({ links: zeplinLink, error: null, loading: false });
+            setState({ links: zeplinLink, error: null, linksLoading: false });
         } else if(Array.isArray(zeplinLink) || typeof zeplinLink !== "string") {
             const formattedValue = JSON.stringify(zeplinLink, null, 2);
-            setState({ links: [], error: `Zeplin link is malformed. Received: ${formattedValue}`, loading: false });
+            setState({ links: [], error: `Zeplin link is malformed. Received: ${formattedValue}`, linksLoading: false });
         } else {
             const projectId = getProjectIdFromProjectLink(zeplinLink);
             const styleguideId = getStyleguideIdFromStyleguideLink(zeplinLink);
             if (projectId || styleguideId) {
-                setState({ links: [], error: null, loading: true });
+                setState({ links: [], error: null, linksLoading: true });
                 getZeplinLinksFromConnectedComponents(
                     storyId,
                     projectId ? { projectId } : { styleguideId }
@@ -76,12 +76,12 @@ export const useLinks = (zeplinLink: unknown): State => {
                         link
                     }));
 
-                    setState({ links: mappedLinks, error: null, loading: false });
+                    setState({ links: mappedLinks, error: null, linksLoading: false });
                 }).catch(error => {
-                    setState({ links: [], error: error?.message ?? String(error), loading: false });
+                    setState({ links: [], error: error?.message ?? String(error), linksLoading: false });
                 });
             } else {
-                setState({ links: [{ link: zeplinLink, name: "Component" }], error: null, loading: false });
+                setState({ links: [{ link: zeplinLink, name: "Component" }], error: null, linksLoading: false });
             }
         }
     }, [zeplinLink]);

--- a/src/components/hooks/useLinks.ts
+++ b/src/components/hooks/useLinks.ts
@@ -84,6 +84,6 @@ export const useLinks = (zeplinLink: unknown): State => {
                 setState({ links: [{ link: zeplinLink, name: "Component" }], error: null, linksLoading: false });
             }
         }
-    }, [zeplinLink]);
+    }, [storyId]);
     return state;
 }


### PR DESCRIPTION
## Description
This PR fixes a  the dependents of a hook from `zeplinLink` to `storyId` to fix a problem where the addon cannot detect that the selected story is changed.

I also changed naming of a state variable `loading` to `linksLoading` to make things more clear. `loading` is also used on another state.

## Why?
Users can set a global `zeplinLink` parameter on `.storybook/preview.js` file to load Zeplin components using Storybook integration feature of Zeplin. Story loading was dependent on `zeplinLink` and it was broken due to the fact that all components share the same link. Users could not see the corresponding Zeplin components when they had clicked on a different story on the left menu, they had to refresh the page to get it.

```js
// .storybook/preview.js file
export const parameters = {
    zeplinLink: "https://app.zeplin.io/project/61964989324da1a90c5ec217",
    ...
};
```