### PR TITLE
Revert Automatic JSX Runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.0.0",
             "license": "MIT",
             "dependencies": {
-                "@storybook/icons": "^1.2.9",
+                "@storybook/icons": "^2.0.1",
                 "@zeplin/sdk": "^1.9.0",
                 "query-string": "^6.12.1"
             },
@@ -886,16 +886,13 @@
             "license": "MIT"
         },
         "node_modules/@storybook/icons": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.6.0.tgz",
-            "integrity": "sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.1.tgz",
+            "integrity": "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==",
             "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@storybook/preset-react-webpack": {
@@ -4703,17 +4700,6 @@
                 "prettier": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/storybook/node_modules/@storybook/icons": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.1.tgz",
-            "integrity": "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/strict-uri-encode": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     },
     "homepage": "https://github.com/zeplin/storybook-zeplin#readme",
     "dependencies": {
-        "@storybook/icons": "^1.2.9",
+        "@storybook/icons": "^2.0.1",
         "@zeplin/sdk": "^1.9.0",
         "query-string": "^6.12.1"
     },

--- a/src/components/HeaderButtons.stories.tsx
+++ b/src/components/HeaderButtons.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import HeaderButtons from "./HeaderButtons";
 
 export default {

--- a/src/components/HeaderButtons.stories.tsx
+++ b/src/components/HeaderButtons.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import HeaderButtons from "./HeaderButtons";
 
 export default {

--- a/src/components/HeaderButtons.tsx
+++ b/src/components/HeaderButtons.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from "react";
+import React, { FunctionComponent } from "react";
 import {
     Button,
     TooltipMessage,

--- a/src/components/MainPanel.tsx
+++ b/src/components/MainPanel.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState } from "react";
+import React, { FunctionComponent, useState } from "react";
 import { styled } from "storybook/theming";
 
 import ZeplinPanel from "./ZeplinPanel";

--- a/src/components/OverlayButtons.tsx
+++ b/src/components/OverlayButtons.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ToggleButton } from "storybook/internal/components";
 import {
     EyeCloseIcon,

--- a/src/components/OverlayButtons.tsx
+++ b/src/components/OverlayButtons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import { ToggleButton } from "storybook/internal/components";
 import {
     EyeCloseIcon,

--- a/src/components/OverlayImage.tsx
+++ b/src/components/OverlayImage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useReducer } from "react";
+import React, { useState, useEffect, useReducer } from "react";
 import { useParameter } from "storybook/manager-api";
 import { styled } from "storybook/theming";
 

--- a/src/components/OverlayPanel.tsx
+++ b/src/components/OverlayPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useReducer, ChangeEvent } from "react";
+import React, { useCallback, useReducer, ChangeEvent } from "react";
 import { Form } from "storybook/internal/components";
 import { styled } from "storybook/theming";
 

--- a/src/components/PATForm.tsx
+++ b/src/components/PATForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, FunctionComponent, useState } from "react";
+import React, { ChangeEvent, FormEvent, FunctionComponent, useState } from "react";
 import { Button, Form, Link } from "storybook/internal/components";
 import { styled } from "storybook/theming";
 

--- a/src/components/PATForm.tsx
+++ b/src/components/PATForm.tsx
@@ -1,4 +1,9 @@
-import React, { ChangeEvent, FormEvent, FunctionComponent, useState } from "react";
+import React, {
+    ChangeEvent,
+    FormEvent,
+    FunctionComponent,
+    useState,
+} from "react";
 import { Button, Form, Link } from "storybook/internal/components";
 import { styled } from "storybook/theming";
 

--- a/src/components/ZeplinPanel.tsx
+++ b/src/components/ZeplinPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useReducer, ChangeEvent } from "react";
+import React, { useEffect, useCallback, useReducer, ChangeEvent } from "react";
 import { Form, Link } from "storybook/internal/components";
 import { styled } from "storybook/theming";
 

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import { addons, types, useParameter } from "storybook/manager-api";
 import { AddonPanel } from "storybook/internal/components";
 

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { addons, types, useParameter } from "storybook/manager-api";
 import { AddonPanel } from "storybook/internal/components";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
         "moduleResolution": "bundler",
         "declaration": true,
         "strict": true,
-        "jsx": "react-jsx",
+        "jsx": "react",
         "forceConsistentCasingInFileNames": true,
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
I was unable to configure Storybook and Vite to use automatic JSX runtime. This will fix issue: https://github.com/zeplin/storybook-zeplin/issues/92